### PR TITLE
Fixed Node Red crash due to re-auth process calling event listener with undefined callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "homepage": "https://github.com/particle-iot/node-red-contrib-particle-official#readme",
   "dependencies": {
     "lodash": "^4.17.21",
-    "particle-api-js": "^9.0.2"
+    "particle-api-js": "^9.4.1"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -165,9 +165,7 @@ module.exports = class Api {
 		this._logger.log('Reauthenticating...');
 		this.cleanup();
 
-		this.login().then(() => {
-			this.listenToEventStream.apply(this, this._lastListenArguments);
-		}, () => {
+		this.login().catch(() => {
 			const retryIn = 5;
 			this._logger.error(`Failed to reauthenticate. Trying again in ${retryIn} seconds`);
 			setTimeout(this._reauthenticate.bind(this), retryIn * 1000);


### PR DESCRIPTION
From reading forums, this appears to have started in Node Red 3.0.  Node Red will crash every 2 hours with this added.

Reviewing the code, I can see no reason for the listenToEventStream being called only during the re-auth process as there is no callback.  I removed this unnecessary call

I tested the subscribe node and it works as-expected